### PR TITLE
Add option to ignore buffers bound to windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ opts = {
 	-- ignore visible buffers (buffers open in a window, "a" in `:buffers`)
 	ignoreVisibleBufs = true,
 
+	-- ignore buffers bound to windows, even from inactive tabs
+	ignoreBoundBufs = false,
+
 	-- uses vim.notify for plugins like nvim-notify
 	notificationOnAutoClose = false,
 }

--- a/doc/early-retirement.txt
+++ b/doc/early-retirement.txt
@@ -70,6 +70,9 @@ CONFIGURATION          *early-retirement-nvim-early-retirement--configuration*
         -- ignore visible buffers (buffers open in a window, "a" in `:buffers`)
         ignoreVisibleBufs = true,
     
+        -- ignore buffers bound to windows, even from inactive tabs
+        ignoreBoundBufs = false,
+    
         -- uses vim.notify for plugins like nvim-notify
         notificationOnAutoClose = false,
     }


### PR DESCRIPTION
This commit adds a new option `ignoreBoundBuf` to prevent buffers bound to windows from being closed.

Reasoning:
I use tabs to organize my workflow. With early retirement enabled I suddenly discovered that all my tabs were closed except active one.
Setting `ignoreBoundBuf` to `true` will prevent this.

Fixes #4