### PR TITLE
feat: add deleteFunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ defaultOpts = {
 	-- associated buffer as well. Requires Neovim >= 0.10.
 	-- (This feature is independent from the automatic closing)
 	deleteBufferWhenFileDeleted = false,
+
+	-- Function to delete the buffer. The argument provided to the function is
+	-- the buffer number. If nothing is provided the plugin will just call
+	-- nvim_buf_delete.
+	deleteFunction = nil,
 }
 ```
 

--- a/lua/early-retirement.lua
+++ b/lua/early-retirement.lua
@@ -108,7 +108,11 @@ local function checkOutdatedBuffer(c)
 		if isModified and not c.ignoreUnsavedChangesBufs then
 			vim.api.nvim_buf_call(buf.bufnr, vim.cmd.write)
 		end
-		vim.api.nvim_buf_delete(buf.bufnr, { force = false, unload = false })
+    if c.deleteFunction then
+      c.deleteFunction(buf.bufnr)
+    else
+      vim.api.nvim_buf_delete(buf.bufnr, { force = false, unload = false })
+    end
 
 		::continue::
 	end
@@ -128,6 +132,7 @@ end
 ---@field minimumBufferNum number minimum number of open buffers for auto-closing to become active
 ---@field ignoreFilenamePattern string ignore files matches this lua pattern (string.find)
 ---@field deleteBufferWhenFileDeleted boolean
+---@field deleteFunction function
 
 ---@param userConfig opts
 function M.setup(userConfig)


### PR DESCRIPTION
User can provide a function that handles deleting of a buffer.

For context:
### Problem
I use tabs. I use a plugin Scope so each tab has its own seperate list of buffers. This enables me to have a workflow where each tab is conceptually and effectively a workspace with its own buffer, window and current directory. As I work on many branches in parallel with `worktrees` it's incredibly useful to me.
### Solution
Add a parameter `deleteBuffer` so your plugin calls my function which checks that closing a buffer is not going to close an entire tab because then I'd lose a valuable workspace which is very disruptive to my workflow.
[See my commit in my config](https://github.com/ilan-schemoul/nvim-config/commit/f378d8109c283c9237ab8465d1f617f17a35fe3d)
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).
